### PR TITLE
fix: 게시글 조회 API 에러 수정

### DIFF
--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards, Query, UseFilters, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards, Query, UseFilters, Patch } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { AtGuard } from 'src/commons/guards/access.token.guard';

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -6,7 +6,6 @@ import { User } from 'src/user/entities/user.entity';
 import { GetUser } from 'src/commons/decorators/get.user.decorator';
 import { ResponseMessage } from 'src/commons/decorators/response.key.decorator';
 import { PostResponseMessage } from 'src/commons/class/post.response.message';
-import { StatsQueryDto } from './dto/stats-query.dto';
 import { PostGuard } from 'src/commons/guards/post.guard';
 import { GetPost } from 'src/commons/decorators/get.post.decorator';
 import { Post as PostType } from './entities/post.entity';
@@ -25,12 +24,6 @@ export class PostController {
 		return await this.postService.createPost(user, createPostDto);
 	}
 
-	@Get('/stats')
-	async getStats(@Query() statsQueryDto: StatsQueryDto) {
-		console.log(statsQueryDto);
-		return await this.postService.getStats(statsQueryDto);
-	}
-
 	@Get('/:postId')
 	@UseGuards(AtGuard, PostGuard)
 	@ResponseMessage(PostResponseMessage.GET_POST)
@@ -45,17 +38,17 @@ export class PostController {
 		return await this.postService.like(post);
 	}
 
-	@Get()
-	@UseGuards(AtGuard)
-	@ResponseMessage(PostResponseMessage.FIND_POSTS)
-	async findPosts(@GetUser() user: User, @Query() query: PostsQueryDto) {
-		return this.postService.findPosts(query, user.account);
-	}
-
 	@Patch('share/:postId')
 	@UseGuards(AtGuard, PostGuard)
 	@ResponseMessage(PostResponseMessage.SHARE)
 	async share(@GetPost() post: PostType) {
 		return await this.postService.share(post);
+	}
+
+	@Get()
+	@UseGuards(AtGuard)
+	@ResponseMessage(PostResponseMessage.FIND_POSTS)
+	async findPosts(@Query() query: PostsQueryDto, @GetUser() user: User) {
+		return this.postService.findPosts(query, user.account);
 	}
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -6,8 +6,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { PostsException, StatsException } from '../commons/exception.message';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostsQueryDto } from './dto/query-post.dto';
-import { orderMappings } from 'src/commons/enums/order-role.enum';
+import { OrderRole, orderMappings } from 'src/commons/enums/order-role.enum';
 import { SearchRole } from 'src/commons/enums/search-role.enum';
+import { SnsProvider } from 'src/commons/enums/sns-provider.enum';
 
 @Injectable()
 export class PostService {
@@ -101,29 +102,27 @@ export class PostService {
 		return posts;
 	}
 
-	async findPosts(query: PostsQueryDto, account: string) {
-		const { type, hashtag, orderBy, order, search, searchBy, page } = query;
-
-		let { pageCount } = query;
-		pageCount = pageCount || 10;
-
-		const qb = this.postRepository.createQueryBuilder('post');
-
-		if (type) qb.where('post.type = :type', { type });
-
+	addHashtag(qb: SelectQueryBuilder<Post>, hashtag: string, account: string) {
 		if (hashtag) {
 			const jsonHashtag = JSON.stringify(hashtag);
 			qb.where('JSON_CONTAINS(post.hashtags, :hashtag) = 1', { hashtag: jsonHashtag });
 		} else {
 			qb.andWhere('JSON_CONTAINS(post.hashtags, JSON_QUOTE(:hashtag)) = 1', { hashtag: account });
 		}
+	}
 
-		if (orderMappings[orderBy]) {
-			qb.orderBy(`post.${orderMappings[orderBy]}`, order === 'asc' ? 'ASC' : 'DESC');
-		}
+	addOrder(qb: SelectQueryBuilder<Post>, orderBy: OrderRole, order: 'asc' | 'desc') {
+		const orderColumn = orderMappings[orderBy];
+		if (orderColumn) qb.orderBy(`post.${orderColumn}`, order === 'asc' ? 'ASC' : 'DESC');
+	}
 
+	addType(qb: SelectQueryBuilder<Post>, type: string) {
+		if (type) qb.andWhere('post.type = :type', { type: type });
+	}
+
+	addSearch(qb: SelectQueryBuilder<Post>, searchBy: SearchRole, search: string) {
 		if (search) {
-			if (searchBy === SearchRole.titleContent) {
+			if (!searchBy || searchBy === SearchRole.titleContent) {
 				qb.andWhere(
 					new Brackets((subQuery) => {
 						subQuery
@@ -135,6 +134,20 @@ export class PostService {
 				qb.andWhere(`post.${SearchRole[searchBy]} LIKE :search`, { search: `%${search}%` });
 			}
 		}
+	}
+
+	async findPosts(query: PostsQueryDto, account: string) {
+		const { type, hashtag, orderBy, order, search, searchBy, page } = query;
+
+		let { pageCount } = query;
+		pageCount = pageCount || 10;
+
+		const qb = this.postRepository.createQueryBuilder('post');
+
+		this.addHashtag(qb, hashtag, account);
+		this.addOrder(qb, orderBy, order);
+		this.addType(qb, type);
+		this.addSearch(qb, searchBy, search);
 
 		const posts = await this.paginateQuery(qb, page, pageCount);
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -3,12 +3,11 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { Repository, Brackets, SelectQueryBuilder } from 'typeorm';
 import { Post } from './entities/post.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { PostsException, StatsException } from '../commons/exception.message';
+import { StatsException } from '../commons/exception.message';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostsQueryDto } from './dto/query-post.dto';
 import { OrderRole, orderMappings } from 'src/commons/enums/order-role.enum';
 import { SearchRole } from 'src/commons/enums/search-role.enum';
-import { SnsProvider } from 'src/commons/enums/sns-provider.enum';
 
 @Injectable()
 export class PostService {


### PR DESCRIPTION
- GET '/posts?type=FACEBOOK' 이처럼 타입을 명시해도 모든 타입의 게시글이 조회되는 문제 수정
- search_by 파라미터 에러 수정
- findPosts 함수 내부 기능들을 별도의 함수로 빼줌

feat-#48