### PR TITLE
fix: HttpExceptionFilter 응답 형식 수정

### DIFF
--- a/src/commons/exception.message.ts
+++ b/src/commons/exception.message.ts
@@ -26,6 +26,10 @@ export class UsersException {
 		message: '인증코드가 일치하지 않습니다.',
 		error: ExceptionObjError.BAD_REQUEST,
 	};
+	static USER_NOT_CERTIFIED: ExceptionObj = {
+		message: '회원 가입 승인이 되지 않은 계정입니다.',
+		error: ExceptionObjError.BAD_REQUEST,
+	};
 }
 
 export class PostsException {

--- a/src/commons/filter/http-exception.filter.ts
+++ b/src/commons/filter/http-exception.filter.ts
@@ -4,16 +4,19 @@ import { Response } from 'express';
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
 	catch(exception: HttpException, host: ArgumentsHost) {
-		const response = host.switchToHttp().getResponse<Response>();
+		const ctx = host.switchToHttp();
+		const response = ctx.getResponse<Response>();
+		const request = ctx.getRequest<Request>();
 		const status = exception.getStatus();
 		const exceptionObj = exception.getResponse(); // ExceptionObj 타입의 객체
 
 		response.status(status).json({
 			success: false,
-			message: exceptionObj['message'],
-			status,
+			statusCode: status,
 			error: exceptionObj['error'],
-			date: new Date().toISOString(), // 2023-10-27T14:30:20.123Z
+			message: exceptionObj['message'],
+			timestamp: new Date().toISOString(), // 2023-10-27T14:30:20.123Z
+			path: request.url,
 		});
 	}
 }

--- a/src/user/dto/approve-user.dto.ts
+++ b/src/user/dto/approve-user.dto.ts
@@ -4,8 +4,12 @@ import { IsNotEmpty, IsNumberString, MaxLength, MinLength } from 'class-validato
 
 export class ApproveUserDto extends OmitType(CreateUserDto, ['email'] as const) {
 	@IsNumberString()
-	@MinLength(6)
-	@MaxLength(6)
+	@MinLength(6, {
+		message: '가입승인코드는 6자리입니다.',
+	})
+	@MaxLength(6, {
+		message: '가입승인코드는 6자리입니다.',
+	})
 	@IsNotEmpty()
 	signupCode: string;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -30,7 +30,7 @@ export class UserService {
 		if (isExist) {
 			const user = await this.findOne({ account });
 
-			if (!user.isCertify) throw new BadRequestException('회원 가입 승인이 되지 않은 계정입니다.');
+			if (!user.isCertify) throw new BadRequestException(UsersException.USER_NOT_CERTIFIED);
 
 			const isMatched = await bcrypt.compare(password, user.password);
 
@@ -46,10 +46,10 @@ export class UserService {
 				};
 			}
 
-			throw new BadRequestException('패스워드가 일치하지 않습니다.');
+			throw new BadRequestException(UsersException.USER_PASSWORD_NOT_MATCHED);
 		}
 
-		throw new BadRequestException('존재하지 않는 계정입니다.');
+		throw new BadRequestException(UsersException.USER_NOT_EXISTS);
 	}
 
 	async refresh(user: User) {


### PR DESCRIPTION
수정사항
- HttpExceptionFilter가 공통 응답 형식을 반환하도록 수정
- login 서비스 로직에서 문자열 대신 정의해둔 예외 객체를 던지도록 수정
- approve-user.dto.ts 유효성 검사 메세지 수정
- UsersException 클래스에 '회원 가입 승인이 되지 않은 계정입니다.'에 대한 예외 객체 스태틱 프로퍼티 추가